### PR TITLE
fix: remove console error

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ class NxGroupRunner extends GroupRunner {
         const groups = Array.isArray(config.overrides.group) ? config.overrides.group : [config.overrides.group];
         process.argv.push(...groups.map(group => `--group=${group}`));
       }
-    } catch (e) {
-      console.error(e);
-    }
+    } catch (e) { }
     return super.runTests(tests, watcher, onStart, onResult, onFailure, options);
   }
 }


### PR DESCRIPTION
This is to avoid the following error showing up every time running a test e.g. from VSCode or WebStorm instead of the CLI via NX:

SyntaxError: Unexpected token / in JSON at position 0
    at JSON.parse (<anonymous>)
    at NxGroupRunner.runTests ...